### PR TITLE
Sync latest KlusterletConfig CRD from cluster-lifecycle-api

### DIFF
--- a/pkg/templates/crds/foundation/config.open-cluster-management.io_klusterletconfigs_crd.yaml
+++ b/pkg/templates/crds/foundation/config.open-cluster-management.io_klusterletconfigs_crd.yaml
@@ -49,53 +49,6 @@ spec:
                   set to "INFINITE", it means the AppliedManifestWorks will never been evicted from the managed cluster.
                 pattern: ^([0-9]+(s|m|h))+$|^INFINITE$
                 type: string
-              bootstrapKubeConfigs:
-                description: |-
-                  BootstrapKubeConfigSecrets is the list of secrets that reflects the
-                  Klusterlet.Spec.RegistrationConfiguration.BootstrapKubeConfigs.
-                properties:
-                  localSecretsConfig:
-                    description: |-
-                      LocalSecretsConfig include a list of secrets that contains the kubeconfigs for ordered bootstrap kubeconifigs.
-                      The secrets must be in the same namespace where the agent controller runs.
-                    properties:
-                      hubConnectionTimeoutSeconds:
-                        default: 600
-                        description: |-
-                          HubConnectionTimeoutSeconds is used to set the timeout of connecting to the hub cluster.
-                          When agent loses the connection to the hub over the timeout seconds, the agent do a rebootstrap.
-                          By default is 10 mins.
-                        format: int32
-                        minimum: 180
-                        type: integer
-                      kubeConfigSecrets:
-                        description: KubeConfigSecrets is a list of secret names.
-                          The secrets are in the same namespace where the agent controller
-                          runs.
-                        items:
-                          properties:
-                            name:
-                              description: Name is the name of the secret.
-                              type: string
-                          required:
-                          - name
-                          type: object
-                        type: array
-                    required:
-                    - kubeConfigSecrets
-                    type: object
-                  type:
-                    default: None
-                    description: |-
-                      Type specifies the type of priority bootstrap kubeconfigs.
-                      By default, it is set to None, representing no priority bootstrap kubeconfigs are set.
-                    enum:
-                    - None
-                    - LocalSecrets
-                    type: string
-                required:
-                - type
-                type: object
               clusterClaimConfiguration:
                 description: |-
                   ClusterClaimConfiguration represents the configuration of ClusterClaim
@@ -272,6 +225,67 @@ spec:
                     enum:
                     - default
                     - noOperator
+                    type: string
+                type: object
+              multipleHubsConfig:
+                description: MultipleHubsConfig contains configuration specific to
+                  multiple hub scenarios
+                properties:
+                  bootstrapKubeConfigs:
+                    description: BootstrapKubeConfigs is the list of bootstrap kubeconfigs
+                      for multiple hubs
+                    properties:
+                      localSecretsConfig:
+                        description: |-
+                          LocalSecretsConfig include a list of secrets that contains the kubeconfigs for ordered bootstrap kubeconifigs.
+                          The secrets must be in the same namespace where the agent controller runs.
+                        properties:
+                          hubConnectionTimeoutSeconds:
+                            default: 600
+                            description: |-
+                              HubConnectionTimeoutSeconds is used to set the timeout of connecting to the hub cluster.
+                              When agent loses the connection to the hub over the timeout seconds, the agent do a rebootstrap.
+                              By default is 10 mins.
+                            format: int32
+                            minimum: 180
+                            type: integer
+                          kubeConfigSecrets:
+                            description: KubeConfigSecrets is a list of secret names.
+                              The secrets are in the same namespace where the agent
+                              controller runs.
+                            items:
+                              properties:
+                                name:
+                                  description: Name is the name of the secret.
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            type: array
+                        required:
+                        - kubeConfigSecrets
+                        type: object
+                      type:
+                        default: None
+                        description: |-
+                          Type specifies the type of priority bootstrap kubeconfigs.
+                          By default, it is set to None, representing no priority bootstrap kubeconfigs are set.
+                        enum:
+                        - None
+                        - LocalSecrets
+                        type: string
+                    required:
+                    - type
+                    type: object
+                  genBootstrapKubeConfigStrategy:
+                    default: Default
+                    description: |-
+                      GenBootstrapKubeConfigStrategy controls the strategy for generating bootstrap kubeconfig files.
+                      Default - Generate bootstrap kubeconfigs only with the BootstrapKubeConfigs configured in KlusterletConfig.
+                      IncludeCurrentHub - When generating bootstrap kubeconfigs, automatically include the current hub's kubeconfig.
+                    enum:
+                    - Default
+                    - IncludeCurrentHub
                     type: string
                 type: object
               nodePlacement:


### PR DESCRIPTION
This PR syncs the latest KlusterletConfig CRD from the cluster-lifecycle-api repository.